### PR TITLE
check for very large or infinity float64 in the alpha parameter to prevent an infinite loop

### DIFF
--- a/gamma.go
+++ b/gamma.go
@@ -21,7 +21,7 @@ func NewGammaGenerator(seed int64) *GammaGenerator {
 
 // Gamma returns a random number of gamma distribution (alpha > 0.0 and beta > 0.0)
 func (grng GammaGenerator) Gamma(alpha, beta float64) float64 {
-	if !(alpha > 0.0) || !(beta > 0.0) {
+	if !(alpha > 0.0) || !(beta > 0.0) || alpha > math.MaxFloat64/2 {
 		panic(fmt.Sprintf("Invalid parameter alpha %.2f beta %.2f", alpha, beta))
 	}
 


### PR DESCRIPTION
Hello
There is an infinite loop in the gamma function. Reproduction:

```go
func TestInfinityGamma(t *testing.T) {
	g := NewGammaGenerator(0)

	fmt.Println(g.Gamma(math.MaxFloat64/2, 1)) // this will be ok

	fmt.Println(g.Gamma(math.MaxFloat64, 1)) // infinite loop
	fmt.Println(g.Gamma(math.Inf(1), 1))     // infinite loop
}
```

I added a check for values bigger than math.MaxFloat64/2, to prevent this.